### PR TITLE
W1 - del notebook arg from `fig.show()`

### DIFF
--- a/docs/workshop-1/module-1-colab.ipynb
+++ b/docs/workshop-1/module-1-colab.ipynb
@@ -1881,7 +1881,7 @@
     }
    ],
    "source": [
-    "fig.show('notebook')"
+    "fig.show()"
    ]
   },
   {

--- a/docs/workshop-1/module-2-sample-metadata.ipynb
+++ b/docs/workshop-1/module-2-sample-metadata.ipynb
@@ -2623,7 +2623,7 @@
     "    title=\"Ag3.0 genomes sequenced\",\n",
     "    yaxis_title=\"no. genomes\",\n",
     ")\n",
-    "fig.show('notebook')"
+    "fig.show()"
    ]
   },
   {


### PR DESCRIPTION
In our dev server, figures generated with plotly express in M1 & M2 sometimes require an explicit specification the output source (i.e. `fig.show('notebook')`). This is not the case for these figures on Colab. Previously both versions would render the figure, but now the explicit version will not render on Colab. 

Updating M1&M2 so they do not use the explicit arg. 