### PR TITLE
Adding data access information

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -61,3 +61,6 @@ parts:
     - file: workshop-8/module-2-presenting-results
     - file: workshop-8/module-3-genomic-surveillance-tanzania
     - file: workshop-8/module-4-genomic-surveillance-ghana
+  - caption: General
+    chapters:
+    - file: general/data-access

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -61,6 +61,6 @@ parts:
     - file: workshop-8/module-2-presenting-results
     - file: workshop-8/module-3-genomic-surveillance-tanzania
     - file: workshop-8/module-4-genomic-surveillance-ghana
-  - caption: General
+  - caption: Malaria Vector Genome Observatory
     chapters:
     - file: general/data-access

--- a/docs/general/data-access.ipynb
+++ b/docs/general/data-access.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c9aacc94",
+   "metadata": {},
+   "source": [
+    "# Data access\n",
+    "\n",
+    "Vector Observatory data are stored in Google Cloud Storage (GCS) in the US region. The current set-up requires users to request access and authenticate prior to accessing data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab9a09e4",
+   "metadata": {},
+   "source": [
+    "## Fair Usage\n",
+    "\n",
+    "Vector Observatory data are currently stored in Google Cloud Storage (GCS) in the US region. Access to Vector Observatory data in Google Cloud is free for all users. However, large transfers of data outside of Google Cloud in the US region substantially increase our running costs, and so we ask users to adhere to the following fair usage policy. This will allow us to continue making the data freely available.\n",
+    "\n",
+    "- **Data access from Google Colab -** If you are using Google Colab to access data, please check if your allocated virtual machine (VM) is within the US region. If not, please request a new VM by selecting \"Runtime > Disconnect and delete runtime\" from the Colab menu. \n",
+    "\n",
+    "Please note that we monitor data access logs to detect any unexpected large data transfers outside of Google Cloud in the US region, and may temporarily suspend access to users performing large data transfers. If we do suspend access, we will reach out to you to see if we can help optimise your data access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4f316d2",
+   "metadata": {},
+   "source": [
+    "## Data Access using Google Colab\n",
+    "To access data from the Vector Observatory, you will need to follow these steps:\n",
+    "\n",
+    "### Step 1. Make sure you have a Google Account\n",
+    "\n",
+    "To allow us to configure data access permissions, you will need to provide us with an email address that is associated with a Google account. This could be a standard Google (i.e., Gmail) account, or alternatively it could be your work email address if your employer uses Google Workspace.\n",
+    "\n",
+    "### Step 2. Fill out the data access request form\n",
+    "\n",
+    "Please fill out and submit the following form:\n",
+    "\n",
+    "> [MalariaGEN cloud data access form](https://forms.gle/kCqistorZyxaU4LP7)\n",
+    "\n",
+    "All requests for data access will be granted subject to verification checks and agreement to reasonable use. This is to ensure that the data resources remain accessible to everyone. Submitting this form will allow us to configure storage permissions and monitor storage for excessive network usage in future.\n",
+    "\n",
+    "### Step 3. Ensure you are using the latest version of the `malariagen_data` Python package\n",
+    "\n",
+    "If you access data via the `malariagen_data` Python package, please upgrade to version 9.0 or higher. These versions will automatically use your authentication credentials when accessing data in Google Cloud.\n",
+    "\n",
+    "### Step 4. Ensure you are using the same Google Account you registered with\n",
+    "\n",
+    "When you start running some code in Google Colab using the `malariagen_data` Python package, you will be asked to authenticate with your Google Account. Make sure that you use the same account you used during Steps 1 and 2 as you will not be able to use the `malariagen_data` Python package otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4ec7002",
+   "metadata": {},
+   "source": [
+    "If you have any questions during the course of the workshop, feel free to ask your Teaching Assistant. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74917aab",
+   "metadata": {},
+   "source": [
+    "If you have any questions outside of the course of the workshop, please contact us at: <support@malariagen.net>. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37b27bd8",
+   "metadata": {},
+   "source": [
+    "More general details about Data Access can also be found on the [Vector Observatory website](https://malariagen.github.io/vector-data/vobs/vobs-data-access.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "468610d5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/general/data-access.ipynb
+++ b/docs/general/data-access.ipynb
@@ -5,7 +5,7 @@
    "id": "c9aacc94",
    "metadata": {},
    "source": [
-    "# Data access\n",
+    "# Vector Observatory Data Access\n",
     "\n",
     "Vector Observatory data are stored in Google Cloud Storage (GCS) in the US region. The current set-up requires users to request access and authenticate prior to accessing data."
    ]

--- a/docs/home.md
+++ b/docs/home.md
@@ -9,6 +9,47 @@
 Welcome to this training course on data analysis for genomic surveillance of African malaria vectors, developed jointly by [MalariaGEN](https://www.malariagen.net) and [PAMCA](https://www.pamca.org). 
 
 
+## Data access
+
+Vector Observatory data are stored in Google Cloud Storage (GCS) in the US region. The current set-up requires users to request access and authenticate prior to accessing data. 
+
+### Fair Usage
+
+Vector Observatory data are currently stored in Google Cloud Storage (GCS) in the US region. Access to Vector Observatory data in Google Cloud is free for all users. However, large transfers of data outside of Google Cloud in the US region substantially increase our running costs, and so we ask users to adhere to the following fair usage policy. This will allow us to continue making the data freely available.
+
+- **Data access from Google Colab -** If you are using Google Colab to access data, please check if your allocated virtual machine (VM) is within the US region. If not, please request a new VM by selecting “Runtime > Disconnect and delete runtime” from the Colab menu. 
+
+Please note that we monitor data access logs to detect any unexpected large data transfers outside of Google Cloud in the US region, and may temporarily suspend access to users performing large data transfers. If we do suspend access, we will reach out to you to see if we can help optimise your data access.
+
+### Data Access using Google Colab
+To access data from the Vector Observatory, you will need to follow these steps:
+
+#### Step 1. Make sure you have a Google Account
+
+To allow us to configure data access permissions, you will need to provide us with an email address that is associated with a Google account. This could be a standard Google (i.e., Gmail) account, or alternatively it could be your work email address if your employer uses Google Workspace.
+
+#### Step 2. Fill out the data access request form
+
+Please fill out and submit the following form:
+
+> [MalariaGEN cloud data access form](https://forms.gle/kCqistorZyxaU4LP7)
+
+All requests for data access will be granted subject to verification checks and agreement to reasonable use. This is to ensure that the data resources remain accessible to everyone. Submitting this form will allow us to configure storage permissions and monitor storage for excessive network usage in future.
+
+#### Step 3. Ensure you are using the latest version of the `malariagen_data` Python package
+
+If you access data via the `malariagen_data` Python package, please upgrade to version 9.0 or higher. These versions will automatically use your authentication credentials when accessing data in Google Cloud.
+
+#### Step 4. Ensure you are using the same Google Account you registered with
+
+When you start running some code in Google Colab using the `malariagen_data` Python package, you will be asked to authenticate with your Google Account. Make sure that you use the same account you used during Steps 1 and 2 as you will not be able to use the `malariagen_data` Python package otherwise.
+
+If you have any questions during the course of the workshop, feel free to ask your Teaching Assistant. 
+
+If you have any questions outside of the course of the workshop, please contact us at: <support@malariagen.net>. 
+
+More general details about Data Access can also be found on the [Vector Observatory website](https://malariagen.github.io/vector-data/vobs/vobs-data-access.html).
+
 ## Workshop programme
 
 The course will consist of a series of workshops. The workshop programme is as follows:

--- a/docs/home.md
+++ b/docs/home.md
@@ -8,48 +8,6 @@
 
 Welcome to this training course on data analysis for genomic surveillance of African malaria vectors, developed jointly by [MalariaGEN](https://www.malariagen.net) and [PAMCA](https://www.pamca.org). 
 
-
-## Data access
-
-Vector Observatory data are stored in Google Cloud Storage (GCS) in the US region. The current set-up requires users to request access and authenticate prior to accessing data. 
-
-### Fair Usage
-
-Vector Observatory data are currently stored in Google Cloud Storage (GCS) in the US region. Access to Vector Observatory data in Google Cloud is free for all users. However, large transfers of data outside of Google Cloud in the US region substantially increase our running costs, and so we ask users to adhere to the following fair usage policy. This will allow us to continue making the data freely available.
-
-- **Data access from Google Colab -** If you are using Google Colab to access data, please check if your allocated virtual machine (VM) is within the US region. If not, please request a new VM by selecting “Runtime > Disconnect and delete runtime” from the Colab menu. 
-
-Please note that we monitor data access logs to detect any unexpected large data transfers outside of Google Cloud in the US region, and may temporarily suspend access to users performing large data transfers. If we do suspend access, we will reach out to you to see if we can help optimise your data access.
-
-### Data Access using Google Colab
-To access data from the Vector Observatory, you will need to follow these steps:
-
-#### Step 1. Make sure you have a Google Account
-
-To allow us to configure data access permissions, you will need to provide us with an email address that is associated with a Google account. This could be a standard Google (i.e., Gmail) account, or alternatively it could be your work email address if your employer uses Google Workspace.
-
-#### Step 2. Fill out the data access request form
-
-Please fill out and submit the following form:
-
-> [MalariaGEN cloud data access form](https://forms.gle/kCqistorZyxaU4LP7)
-
-All requests for data access will be granted subject to verification checks and agreement to reasonable use. This is to ensure that the data resources remain accessible to everyone. Submitting this form will allow us to configure storage permissions and monitor storage for excessive network usage in future.
-
-#### Step 3. Ensure you are using the latest version of the `malariagen_data` Python package
-
-If you access data via the `malariagen_data` Python package, please upgrade to version 9.0 or higher. These versions will automatically use your authentication credentials when accessing data in Google Cloud.
-
-#### Step 4. Ensure you are using the same Google Account you registered with
-
-When you start running some code in Google Colab using the `malariagen_data` Python package, you will be asked to authenticate with your Google Account. Make sure that you use the same account you used during Steps 1 and 2 as you will not be able to use the `malariagen_data` Python package otherwise.
-
-If you have any questions during the course of the workshop, feel free to ask your Teaching Assistant. 
-
-If you have any questions outside of the course of the workshop, please contact us at: <support@malariagen.net>. 
-
-More general details about Data Access can also be found on the [Vector Observatory website](https://malariagen.github.io/vector-data/vobs/vobs-data-access.html).
-
 ## Workshop programme
 
 The course will consist of a series of workshops. The workshop programme is as follows:
@@ -62,6 +20,14 @@ The course will consist of a series of workshops. The workshop programme is as f
 * {doc}`workshop-6/about`
 * {doc}`workshop-7/about`
 * {doc}`workshop-8/about`
+
+## Data access
+
+Vector Observatory data are stored in Google Cloud Storage (GCS) in the US region. The current set-up requires users to request access and authenticate prior to accessing data. 
+
+A summary of the process to access the data and authenticate can be found here:
+
+* {doc}`general/data-access`
 
 ## Context and motivation
 


### PR DESCRIPTION
First draft of additional data access info.

I felt like having just a link to the info in `home.md` or having the text after the list of workshops might reduce its visibility but it might be too visible right now. 

I tried to remove everything that was not about how the data is accessed during the workshops and to add things that were more specific to the workshops but I may have kept things that are not needed or forgotten important details.