### PR TITLE
W3M1&2 - Maintenance and Updates - 270325

### DIFF
--- a/docs/workshop-3/module-2-population-structure.ipynb
+++ b/docs/workshop-3/module-2-population-structure.ipynb
@@ -112,14 +112,22 @@
     "%%html\n",
     "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/gUKX5SikxUM\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6dc254d-eb32-45ff-aa07-df3d3f6b4d5a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "developer-developer-training-nb-maintenance-mgen-7.10.0",
+   "display_name": "developer-developer-training-nb-maintenance-mgen-15.0.1",
    "language": "python",
-   "name": "conda-env-developer-developer-training-nb-maintenance-mgen-7.10.0-py"
+   "name": "conda-env-developer-developer-training-nb-maintenance-mgen-15.0.1-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -131,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.11"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Partially addresses #298.

Somehow, the `.xlsx` files in Module 1 were still in `vo_agam_release`, I moved them to S3. The data that is shown stops in 2021. If the data is available, do we want to update the notebooks?

Module 2 is just a video so there was not much to do.

For the record:
Module 3 is stuck at IGV so we will need to sort that out first.

Module 4 is the new NJT module and it is already using the most recent environment.