### PR TITLE
Add WIP modules for Af training - second wave of comments

### DIFF
--- a/docs/advanced-training-materials/funestus_IR.ipynb
+++ b/docs/advanced-training-materials/funestus_IR.ipynb
@@ -39,7 +39,9 @@
     "tags": []
    },
    "source": [
-    "This module provides a quick overview of various methods that can be used to detect and analyse signals of insecticide resistance in whole-genome sequenced *Anopheles funestus* mosquitoes using the _Af1_ resource."
+    "This module provides a quick overview of various methods that can be used to detect and analyse signals of insecticide resistance in whole-genome sequenced *Anopheles funestus* mosquitoes using the _Af1_ resource.\n",
+    "\n",
+    "The goal of this module is to show an example of a possible analysis plan using the _Af1_ resource. This analysis plan is no exhaustive and will need to be adapted to the specific questions one is interested in but it should provide a solid basis on which to build further analyses."
    ]
   },
   {
@@ -47,7 +49,9 @@
    "id": "5b2bfe76-af67-4187-8716-9461e3403f8e",
    "metadata": {},
    "source": [
-    "A certain degree of familiarity with the content of the training course on _Anopheles gambiae s.l._ is expected. Many of the concepts presented in this module were introduced in the training course and we will refer to the relevant workshop and module instead of giving detailed explanations."
+    "A certain degree of familiarity with the content of the training course on _Anopheles gambiae s.l._ is expected. Many of the concepts presented in this module were introduced in the training course and we will refer to the relevant workshop and module instead of giving detailed explanations.\n",
+    "\n",
+    "More specifically, this module will use some functions to access SNP and CNV frequencies (which can be found, respectively, in [Workshop 1](https://anopheles-genomic-surveillance.github.io/workshop-1/about.html) and [Workshop 2](https://anopheles-genomic-surveillance.github.io/workshop-2/about.html)) as well as H12 (which was covered in [Workshop 6 - Module 3](https://anopheles-genomic-surveillance.github.io/workshop-6/module-3-gwss.html)) to detect signals of selection. We will also look at gene flow for which methods were introduced in [Workshop 7](https://anopheles-genomic-surveillance.github.io/workshop-7/about.html). Users are encouraged to go back to these workshops to refamiliarize themselves with their content."
    ]
   },
   {


### PR DESCRIPTION
Partially addresses #328 .

For the third comment ("Take out in-code Ag3 references (e.g. some code referencing gcx*'s)"), I removed the references to gcx* but I kept the references to gambiae and coluzzii as they are actually useful when comparing the two resources.

For the fourth comment ("Consider whether there is any room to emphasise how you can look at data in both of the Ag/Af APIs in the same session (Chris mentioned whether on the pop structure module)"), there were already a few parts that used both resources in the pop structure module so I didn't add any but if someone wants to point out places where it would help, I am more than willing to add more.